### PR TITLE
Improve async handling and logging

### DIFF
--- a/app/ontology_searcher.py
+++ b/app/ontology_searcher.py
@@ -1,7 +1,9 @@
 from typing import List, Dict
 import asyncio
+import logging
 
 import openai
+import weaviate
 
 from .config import OPENAI_API_KEY, DEFAULT_K
 from .ontology_manager import OntologyManager
@@ -11,6 +13,7 @@ class OntologySearcher:
     def __init__(self, manager: OntologyManager, openai_api_key: str = OPENAI_API_KEY):
         self.manager = manager
         openai.api_key = openai_api_key
+        self.logger = logging.getLogger(__name__)
 
     async def _embed_passage(self, passage: str) -> List[float]:
         response = await openai.embeddings.create(input=passage, model="text-embedding-ada-002")
@@ -21,12 +24,18 @@ class OntologySearcher:
     ) -> List[Dict]:
         client = await self.manager.get_weaviate_client()
         embedding = await self._embed_passage(passage)
-        result = await asyncio.to_thread(
-            lambda: client.query.get(ontology_collection, ["id", "name", "definition"])
-            .with_near_vector({"vector": embedding})
-            .with_limit(k)
-            .do()
-        )
+        try:
+            result = await asyncio.to_thread(
+                lambda: client.query.get(ontology_collection, ["id", "name", "definition"])
+                .with_near_vector({"vector": embedding})
+                .with_limit(k)
+                .do()
+            )
+        except weaviate.exceptions.WeaviateBaseError as e:
+            self.logger.exception(
+                f"Weaviate query failed for collection {ontology_collection}"
+            )
+            return []
         hits = result.get("data", {}).get("Get", {}).get(ontology_collection, [])
         candidates = []
         for hit in hits:

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -31,7 +31,9 @@ if st.button("Resolve"):
         st.error(resp.text)
 
 st.sidebar.header("Admin Panel")
-api_key = st.sidebar.text_input("API Key", type="password")
+api_key = st.sidebar.text_input(
+    "API Key", type="password", value=os.getenv("ADMIN_API_KEY", "")
+)
 
 st.sidebar.subheader("Update Ontology")
 ont_update = st.sidebar.selectbox("Ontology", ["GO", "DOID"], key="upd")


### PR DESCRIPTION
## Summary
- use asyncio.to_thread for Weaviate schema operations
- log ontology collection creation steps
- handle Weaviate query errors
- show admin API key by default in Streamlit

## Testing
- `python -m py_compile app/ontology_manager.py app/ontology_searcher.py streamlit_app.py`